### PR TITLE
Add support for google analytics 4

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -18,7 +18,7 @@
 <link rel="stylesheet" href="{{ "/css/bulma.min.css" | relURL }}">
 
 {{ if not (in (string .Site.BaseURL) "localhost") }}
-{{ template "_internal/google_analytics_async.html" . }}
+{{ template "_internal/google_analytics.html" . }}
 {{ end }}
 
 <script src={{ "/js/ramium.js" | relURL }}></script>


### PR DESCRIPTION
According to Hugo documentation gtags are supported only with the non async code
https://gohugo.io/templates/internal/#google-analytics

Also another discussion
according to https://discourse.gohugo.io/t/how-to-make-site-updates-to-support-google-analytics-4/38271/2

Analytics will break soon in July 2023 for Google universal Analytics so everyone should migrate to analytics 4 

Migrating after this change should be easy as changing the ID to GTAG